### PR TITLE
Allow files as input for StreamingIterator

### DIFF
--- a/requests_toolbelt/streaming_iterator.py
+++ b/requests_toolbelt/streaming_iterator.py
@@ -42,8 +42,18 @@ class StreamingIterator(object):
 
         r = requests.post(url, data=StreamingIterator(size, iterator))
 
+    You can also pass file-like objects to :py:class:`StreamingIterator` in
+    case requests can't determize the filesize itself. This is the case with
+    streaming file objects like ``stdin`` or any sockets. **Wrapping e.g. files
+    that are on disk with ``StreamingIterator`` is unnecessary**, because
+    requests can determize the filesize itself.
+
     Naturally, you should also set the `Content-Type` of your upload
     appropriately because the toolbelt will not attempt to guess that for you.
+
+    .. versionchanged:: 0.4
+
+        Files are accepted as input.
 
     """
 

--- a/requests_toolbelt/streaming_iterator.py
+++ b/requests_toolbelt/streaming_iterator.py
@@ -60,6 +60,23 @@ class StreamingIterator(object):
         #: body. See bug #80 for more details
         self.len = self.size
 
+        #: Encoding the input data is using
+        self.encoding = encoding
+
+        #: The iterator used to generate the upload data
+        self.iterator = iterator
+
+        if hasattr(iterator, 'read'):
+            self._file = iterator
+        else:
+            self._file = _IteratorAsBinaryFile(iterator, encoding)
+
+    def read(self, size=-1):
+        return encode_with(self._file.read(size), self.encoding)
+
+
+class _IteratorAsBinaryFile(object):
+    def __init__(self, iterator, encoding='utf-8'):
         #: The iterator used to generate the upload data
         self.iterator = iterator
 

--- a/requests_toolbelt/streaming_iterator.py
+++ b/requests_toolbelt/streaming_iterator.py
@@ -44,9 +44,9 @@ class StreamingIterator(object):
 
     You can also pass file-like objects to :py:class:`StreamingIterator` in
     case requests can't determize the filesize itself. This is the case with
-    streaming file objects like ``stdin`` or any sockets. **Wrapping e.g. files
-    that are on disk with ``StreamingIterator`` is unnecessary**, because
-    requests can determize the filesize itself.
+    streaming file objects like ``stdin`` or any sockets. Wrapping e.g. files
+    that are on disk with ``StreamingIterator`` is unnecessary, because
+    requests can determine the filesize itself.
 
     Naturally, you should also set the `Content-Type` of your upload
     appropriately because the toolbelt will not attempt to guess that for you.


### PR DESCRIPTION
Fixes #38

The usecase for this is unsized file-like objects like sys.stdin.

This functionality could've been implemented as a classmethod or helper
function. However, when using StreamingIterator with file-like objects,
it would've been quite inefficient to

1.) Read data from the underlying file at a fixed chunk size for the iterator
2.) Then maintain a buffer for the file-like interface provided on top
    of that iterator