### PR TITLE
Use a len attribute instead of the __len__ method

### DIFF
--- a/tests/test_multipart_encoder.py
+++ b/tests/test_multipart_encoder.py
@@ -63,14 +63,14 @@ class TestCustomBytesIO(unittest.TestCase):
     def test_can_get_length(self):
         self.instance.write(b'example')
         self.instance.seek(0, 0)
-        assert len(self.instance) == 7
+        assert self.instance.len == 7
 
     def test_truncates_intelligently(self):
         self.instance.write(b'abcdefghijklmnopqrstuvwxyzabcd')  # 30 bytes
         assert self.instance.tell() == 30
         self.instance.seek(-10, 2)
         self.instance.smart_truncate()
-        assert len(self.instance) == 10
+        assert self.instance.len == 10
         assert self.instance.read() == b'uvwxyzabcd'
         assert self.instance.tell() == 10
 
@@ -112,7 +112,7 @@ class TestMultipartEncoder(unittest.TestCase):
                  'some file': large_file,
                  }
         encoder = MultipartEncoder(parts)
-        total_size = len(encoder)
+        total_size = encoder.len
         read_size = 1024 * 1024 * 128
         already_read = 0
         while True:
@@ -126,7 +126,7 @@ class TestMultipartEncoder(unittest.TestCase):
 
     def test_length_is_correct(self):
         encoded = encode_multipart_formdata(self.parts, self.boundary)[0]
-        assert len(encoded) == len(self.instance)
+        assert len(encoded) == self.instance.len
 
     def test_encodes_with_readable_data(self):
         s = io.BytesIO(b'value')
@@ -181,7 +181,7 @@ class TestMultipartEncoder(unittest.TestCase):
                 )
 
         m = MultipartEncoder(fields=fields)
-        total_size = len(m)
+        total_size = m.len
 
         blocksize = 8192
         read_so_far = 0
@@ -201,7 +201,7 @@ class TestMultipartEncoder(unittest.TestCase):
         }
 
         m = MultipartEncoder(fields=fields)
-        total_size = len(m)
+        total_size = m.len
 
         blocksize = 8192
         read_so_far = 0

--- a/tests/test_multipart_monitor.py
+++ b/tests/test_multipart_monitor.py
@@ -17,7 +17,7 @@ class TestMultipartEncoderMonitor(unittest.TestCase):
         assert self.monitor.content_type == self.encoder.content_type
 
     def test_length(self):
-        assert len(self.encoder) == len(self.monitor)
+        assert self.encoder.len == self.monitor.len
 
     def test_read(self):
         new_encoder = MultipartEncoder(self.fields, self.boundary)
@@ -32,13 +32,13 @@ class TestMultipartEncoderMonitor(unittest.TestCase):
     def test_callback(self):
         callback = Callback(self.monitor)
         self.monitor.callback = callback
-        chunk_size = int(math.ceil(len(self.encoder) / 4.0))
+        chunk_size = int(math.ceil(self.encoder.len / 4.0))
         while self.monitor.read(chunk_size):
             pass
         assert callback.called == 5
 
     def test_bytes_read(self):
-        bytes_to_read = len(self.encoder)
+        bytes_to_read = self.encoder.len
         self.monitor.read()
         assert self.monitor.bytes_read == bytes_to_read
 


### PR DESCRIPTION
On 32-bit architecture, the size of the integer returned by the __len__
method are restricted to the maximum size of an integer in C. Any number
that is larger than 2**32 results in an OverflowError.

requests uses a utility method to determine the length of a body of a
request. By setting `len` as an attribute, we can still take advantage of
super_len's behaviour and we can hack around the OverflowError.

Closes #80