### PR TITLE
Consume content differently

### DIFF
--- a/requests_toolbelt/auth/guess.py
+++ b/requests_toolbelt/auth/guess.py
@@ -23,7 +23,7 @@ class GuessAuth(auth.AuthBase):
 
             # Consume content and release the original connection
             # to allow our new request to reuse the same one.
-            r.content
+            r.raw.read()
             r.raw.release_conn()
             prep = r.request.copy()
             if not hasattr(prep, '_cookies'):


### PR DESCRIPTION
When upgrading from requests 2.6.0 to any newer version, I get:

    Traceback (most recent call last):
      File "/home/untitaker/projects/vdirsyncer/vdirsyncer/cli/tasks.py", line 77, in sync_collection
        force_delete=force_delete
      File "/home/untitaker/projects/vdirsyncer/vdirsyncer/sync.py", line 163, in sync
        b_info.prepare_idents(storage_a.read_only)
      File "/home/untitaker/projects/vdirsyncer/vdirsyncer/sync.py", line 98, in prepare_idents
        for href, etag in self.storage.list():
      File "/home/untitaker/projects/vdirsyncer/vdirsyncer/storage/dav.py", line 527, in list
        headers=headers)
      File "/home/untitaker/projects/vdirsyncer/vdirsyncer/storage/dav.py", line 237, in request
        return utils.http.request(method, url, session=self._session, **more)
      File "/home/untitaker/projects/vdirsyncer/vdirsyncer/utils/http.py", line 80, in request
        r = func(method, url, **kwargs)
      File "/home/untitaker/.local/lib/python2.7/site-packages/requests/sessions.py", line 465, in request
        resp = self.send(prep, **send_kwargs)
      File "/home/untitaker/.local/lib/python2.7/site-packages/requests/sessions.py", line 579, in send
        r = dispatch_hook('response', hooks, r, **kwargs)
      File "/home/untitaker/.local/lib/python2.7/site-packages/requests/hooks.py", line 41, in dispatch_hook
        _hook_data = hook(hook_data, **kwargs)
      File "/home/untitaker/projects/requests-toolbelt/requests_toolbelt/auth/guess.py", line 36, in handle_401
        _r = r.connection.send(prep, **kwargs)
      File "/home/untitaker/.local/lib/python2.7/site-packages/requests/adapters.py", line 415, in send
        raise ConnectionError(err, request=request)
    ConnectionError: ('Connection aborted.', ResponseNotReady())

With a quick Google search I figured that GuessAuth must not be
releasing the connection properly, so I used another way that seemingly
works.

I have no idea why this is actually necessary -- diffing the two
requests versions shows too much to analyze, but no significant changes
have been made in `requests.models`. So it's beyond me why the content
property wouldn't properly consume the request anymore. I'd assume that
HTTP digest auth has similar issues, because GuessAuth's code comes from
there.

Don't actually merge this, it's more for discussion.