### PR TITLE
Add a shim module to plaster over imports

### DIFF
--- a/requests_toolbelt/_compat.py
+++ b/requests_toolbelt/_compat.py
@@ -1,0 +1,21 @@
+"""Private module full of compatibility hacks.
+
+Primarily this is for downstream redistributions of requests that unvendor
+urllib3 without providing a shim.
+
+.. warning::
+
+    This module is private. If you use it, and something breaks, you were
+    warned
+"""
+
+try:
+    from requests.packages.urllib3 import connection
+    from requests.packages.urllib3 import fields
+    from requests.packages.urllib3 import filepost
+    from requests.packages.urllib3 import poolmanager
+except ImportError:
+    from urllib3 import connection  # NOQA
+    from urllib3 import fields  # NOQA
+    from urllib3 import filepost  # NOQA
+    from urllib3 import poolmanager  # NOQA

--- a/requests_toolbelt/adapters/fingerprint.py
+++ b/requests_toolbelt/adapters/fingerprint.py
@@ -5,7 +5,8 @@ This file contains an implementation of a Transport Adapter that validates
 the fingerprints of SSL certificates presented upon connection.
 """
 from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.poolmanager import PoolManager
+
+from .._compat import poolmanager
 
 
 class FingerprintAdapter(HTTPAdapter):
@@ -40,7 +41,8 @@ class FingerprintAdapter(HTTPAdapter):
         super(FingerprintAdapter, self).__init__(**kwargs)
 
     def init_poolmanager(self, connections, maxsize, block=False):
-        self.poolmanager = PoolManager(num_pools=connections,
-                                       maxsize=maxsize,
-                                       block=block,
-                                       assert_fingerprint=self.fingerprint)
+        self.poolmanager = poolmanager.PoolManager(
+            num_pools=connections,
+            maxsize=maxsize,
+            block=block,
+            assert_fingerprint=self.fingerprint)

--- a/requests_toolbelt/adapters/socket_options.py
+++ b/requests_toolbelt/adapters/socket_options.py
@@ -4,8 +4,9 @@ import socket
 
 import requests
 from requests import adapters
-from requests.packages.urllib3 import connection
-from requests.packages.urllib3 import poolmanager
+
+from .._compat import connection
+from .._compat import poolmanager
 
 
 class SocketOptionsAdapter(adapters.HTTPAdapter):

--- a/requests_toolbelt/adapters/source.py
+++ b/requests_toolbelt/adapters/source.py
@@ -7,7 +7,8 @@ This file contains an implementation of the SourceAddressAdapter originally
 demonstrated on the Requests GitHub page.
 """
 from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.poolmanager import PoolManager
+
+from .._compat import poolmanager
 
 
 class SourceAddressAdapter(HTTPAdapter):
@@ -32,7 +33,8 @@ class SourceAddressAdapter(HTTPAdapter):
         super(SourceAddressAdapter, self).__init__(**kwargs)
 
     def init_poolmanager(self, connections, maxsize, block=False):
-        self.poolmanager = PoolManager(num_pools=connections,
-                                       maxsize=maxsize,
-                                       block=block,
-                                       source_address=self.source_address)
+        self.poolmanager = poolmanager.PoolManager(
+            num_pools=connections,
+            maxsize=maxsize,
+            block=block,
+            source_address=self.source_address)

--- a/requests_toolbelt/adapters/ssl.py
+++ b/requests_toolbelt/adapters/ssl.py
@@ -10,7 +10,8 @@ https://lukasa.co.uk/2013/01/Choosing_SSL_Version_In_Requests/
 
 """
 from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.poolmanager import PoolManager
+
+from .._compat import poolmanager
 
 
 class SSLAdapter(HTTPAdapter):
@@ -42,7 +43,8 @@ class SSLAdapter(HTTPAdapter):
         super(SSLAdapter, self).__init__(**kwargs)
 
     def init_poolmanager(self, connections, maxsize, block=False):
-        self.poolmanager = PoolManager(num_pools=connections,
-                                       maxsize=maxsize,
-                                       block=block,
-                                       ssl_version=self.ssl_version)
+        self.poolmanager = poolmanager.PoolManager(
+            num_pools=connections,
+            maxsize=maxsize,
+            block=block,
+            ssl_version=self.ssl_version)

--- a/requests_toolbelt/multipart/encoder.py
+++ b/requests_toolbelt/multipart/encoder.py
@@ -7,13 +7,13 @@ requests_toolbelt.multipart.encoder
 This holds all of the implementation details of the MultipartEncoder
 
 """
-
-from requests.utils import super_len
-from requests.packages.urllib3 import fields
-from uuid import uuid4
-
 import contextlib
 import io
+from uuid import uuid4
+
+from requests.utils import super_len
+
+from .._compat import fields
 
 
 class MultipartEncoder(object):

--- a/tests/test_multipart_encoder.py
+++ b/tests/test_multipart_encoder.py
@@ -2,7 +2,7 @@
 import unittest
 import io
 from requests_toolbelt.multipart.encoder import CustomBytesIO, MultipartEncoder
-from requests.packages.urllib3.filepost import encode_multipart_formdata
+from requests_toolbelt._compat import filepost
 
 
 class LargeFileMock(object):
@@ -103,7 +103,8 @@ class TestMultipartEncoder(unittest.TestCase):
         assert self.instance.content_type == expected
 
     def test_encodes_data_the_same(self):
-        encoded = encode_multipart_formdata(self.parts, self.boundary)[0]
+        encoded = filepost.encode_multipart_formdata(self.parts,
+                                                     self.boundary)[0]
         assert encoded == self.instance.read()
 
     def test_streams_its_data(self):
@@ -125,7 +126,8 @@ class TestMultipartEncoder(unittest.TestCase):
         assert already_read == total_size
 
     def test_length_is_correct(self):
-        encoded = encode_multipart_formdata(self.parts, self.boundary)[0]
+        encoded = filepost.encode_multipart_formdata(self.parts,
+                                                     self.boundary)[0]
         assert len(encoded) == self.instance.len
 
     def test_encodes_with_readable_data(self):

--- a/tests/test_socket_options_adapter.py
+++ b/tests/test_socket_options_adapter.py
@@ -5,7 +5,7 @@ import socket
 
 import mock
 import requests
-from requests.packages.urllib3 import poolmanager
+from requests_toolbelt._compat import poolmanager
 
 from requests_toolbelt.adapters import socket_options
 


### PR DESCRIPTION
On different linux distros, urllib3 is de-vendored from requests
breaking requests' API. Since this seems to be a consistent problem,
so we may as well just fix it here.

Closes #82