### PR TITLE
Simplify our .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: python
+sudo: false
 before_script:
 - pip install tox
 - pip install -U requests"$REQUESTS_VERSION"
 
 # test script
-script:  tox -e ${TOX_ENV}
+script:  tox
 notifications:
   on_success: change
   on_failure: always
@@ -12,30 +13,30 @@ notifications:
 env:
   matrix:
   # With latest requests
-  - TOX_ENV=py26 REQUESTS_VERSION=""
-  - TOX_ENV=py27 REQUESTS_VERSION=""
-  - TOX_ENV=py32 REQUESTS_VERSION=""
-  - TOX_ENV=py33 REQUESTS_VERSION=""
-  - TOX_ENV=py34 REQUESTS_VERSION=""
-  - TOX_ENV=pypy REQUESTS_VERSION=""
+  - TOXENV=py26 REQUESTS_VERSION=""
+  - TOXENV=py27 REQUESTS_VERSION=""
+  - TOXENV=py32 REQUESTS_VERSION=""
+  - TOXENV=py33 REQUESTS_VERSION=""
+  - TOXENV=py34 REQUESTS_VERSION=""
+  - TOXENV=pypy REQUESTS_VERSION=""
   # With requests 2.2.1
-  - TOX_ENV=py26 REQUESTS_VERSION="==2.2.1"
-  - TOX_ENV=py27 REQUESTS_VERSION="==2.2.1"
-  - TOX_ENV=py32 REQUESTS_VERSION="==2.2.1"
-  - TOX_ENV=py33 REQUESTS_VERSION="==2.2.1"
-  - TOX_ENV=py34 REQUESTS_VERSION="==2.2.1"
-  - TOX_ENV=pypy REQUESTS_VERSION="==2.2.1"
+  - TOXENV=py26 REQUESTS_VERSION="==2.2.1"
+  - TOXENV=py27 REQUESTS_VERSION="==2.2.1"
+  - TOXENV=py32 REQUESTS_VERSION="==2.2.1"
+  - TOXENV=py33 REQUESTS_VERSION="==2.2.1"
+  - TOXENV=py34 REQUESTS_VERSION="==2.2.1"
+  - TOXENV=pypy REQUESTS_VERSION="==2.2.1"
   # With requets 2.1.0
-  - TOX_ENV=py26 REQUESTS_VERSION="==2.1.0"
-  - TOX_ENV=py27 REQUESTS_VERSION="==2.1.0"
-  - TOX_ENV=py32 REQUESTS_VERSION="==2.1.0"
-  - TOX_ENV=py33 REQUESTS_VERSION="==2.1.0"
-  - TOX_ENV=py34 REQUESTS_VERSION="==2.1.0"
-  - TOX_ENV=pypy REQUESTS_VERSION="==2.1.0"
-  - TOX_ENV=py27-flake8
-  - TOX_ENV=py34-flake8
-  - TOX_ENV=docstrings
+  - TOXENV=py26 REQUESTS_VERSION="==2.1.0"
+  - TOXENV=py27 REQUESTS_VERSION="==2.1.0"
+  - TOXENV=py32 REQUESTS_VERSION="==2.1.0"
+  - TOXENV=py33 REQUESTS_VERSION="==2.1.0"
+  - TOXENV=py34 REQUESTS_VERSION="==2.1.0"
+  - TOXENV=pypy REQUESTS_VERSION="==2.1.0"
+  - TOXENV=py27-flake8
+  - TOXENV=py34-flake8
+  - TOXENV=docstrings
 
 matrix:
   allow_failures:
-  - env: TOX_ENV=docstrings
+  - env: TOXENV=docstrings


### PR DESCRIPTION
- Use TOXENV instead of TOX_ENV since tox will automatically understand
  TOXENV

- Add "sudo: false" to take advantage of Travis' container
  infrastructure