### PR TITLE
tee module

### DIFF
--- a/docs/downloadutils.rst
+++ b/docs/downloadutils.rst
@@ -5,3 +5,9 @@ Utilities for Downloading Streaming Reponses
 
 .. autofunction::
     requests_toolbelt.downloadutils.stream.stream_response_to_file
+
+.. autofunction::
+    requests_toolbelt.downloadutils.tee.tee
+
+.. autofunction::
+    requests_toolbelt.downloadutils.tee.tee_to_file

--- a/requests_toolbelt/downloadutils/tee.py
+++ b/requests_toolbelt/downloadutils/tee.py
@@ -1,0 +1,45 @@
+"""Tee function implementations."""
+
+
+def tee(response, fileobject):
+    """Stream the response both to the generator and a file.
+
+    This will stream the response body while writing the bytes to
+    ``fileobject``.
+
+    Example usage:
+
+    .. code-block:: python
+
+        resp = requests.get(url, stream=True)
+        with open('save_file', 'w+b') as save_file:
+            for chunk in tee(resp, save_file):
+                # do stuff with chunk
+
+    :param response: Response from requests.
+    :type response: requests.Response
+    :param fileobject: Writable file-like object.
+    :type fileobject: file, io.BytesIO
+    """
+    pass
+
+
+def tee_to_file(response, filename):
+    """Stream the response both to the generator and a file.
+
+    This will open a file named ``filename`` and stream the response body
+    while writing the bytes to the opened file object.
+
+    Example usage:
+
+    .. code-block:: python
+
+        resp = requests.get(url, stream=True)
+        for chunk in tee_to_file(resp, 'save_file'):
+            # do stuff with chunk
+
+    :param response: Response from requests.
+    :type response: requests.Response
+    :param str fileoname: Name of file in which we write the response content.
+    """
+    pass

--- a/requests_toolbelt/downloadutils/tee.py
+++ b/requests_toolbelt/downloadutils/tee.py
@@ -1,7 +1,9 @@
 """Tee function implementations."""
 
+_DEFAULT_CHUNKSIZE = 65536
 
-def tee(response, fileobject):
+
+def tee(response, fileobject, chunksize=_DEFAULT_CHUNKSIZE):
     """Stream the response both to the generator and a file.
 
     This will stream the response body while writing the bytes to
@@ -20,11 +22,14 @@ def tee(response, fileobject):
     :type response: requests.Response
     :param fileobject: Writable file-like object.
     :type fileobject: file, io.BytesIO
+    :param int chunksize: (optional), Size of chunk to attempt to stream.
     """
-    pass
+    for chunk in response.raw.stream(amt=chunksize):
+        fileobject.write(chunk)
+        yield chunk
 
 
-def tee_to_file(response, filename):
+def tee_to_file(response, filename, chunksize=_DEFAULT_CHUNKSIZE):
     """Stream the response both to the generator and a file.
 
     This will open a file named ``filename`` and stream the response body
@@ -41,5 +46,8 @@ def tee_to_file(response, filename):
     :param response: Response from requests.
     :type response: requests.Response
     :param str fileoname: Name of file in which we write the response content.
+    :param int chunksize: (optional), Size of chunk to attempt to stream.
     """
-    pass
+    with open(filename, 'wb') as fd:
+        for chunk in tee(response, fd, chunksize):
+            yield chunk


### PR DESCRIPTION
This adds the tee module with two functions for streaming a response and writing it to a file-like object as well as yielding the chunk.

TODO:

- [x] Add tests
- [x] Add documentation

---

I picked the largest download from CirrOS (8+ MB) and tested it out. Given the simplicity, it would be hard for this to fail :D.

```py
>>> import requests
>>> from requests_toolbelt.downloadutils import tee as t
>>> r = requests.get('https://download.cirros-cloud.net/0.3.4/cirros-0.3.4-x86_64-uec.tar.gz', stream=True, verify=False)
>>> fd = open('cirros-0.3.4-x86_64-uec.tar.gz', 'wb')
>>> sum(len(c) for c in t.tee(r, fd))
8683894
>>> r.headers['content-length']
'8683894'
>>> fd.close()
```