### PR TITLE
Fix #91 - Avoid importing package in setup.py for version.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -29,3 +29,5 @@ Patches and Suggestions
 - Zhaoyu Luo <luozhaoyu90@gmail.com>
 
 - Markus Unterwaditzer <markus@unterwaditzer.net>
+
+- Bryce Boe <bbzbryce@gmail.com> (@bboe)

--- a/setup.py
+++ b/setup.py
@@ -22,10 +22,7 @@ def get_version():
                 break
     return version
 
-try:
-    from requests_toolbelt import __version__
-except:
-    __version__ = get_version()
+__version__ = get_version()
 
 if not __version__:
     raise RuntimeError('Cannot find version information')


### PR DESCRIPTION
Importing the package to obtain the version number can result in unexpected
behavior (see #91) and thus the version number should only be obtained through
searching for the version string in the source file.