### PR TITLE
Allow string types for source address adapter.

### DIFF
--- a/requests_toolbelt/_compat.py
+++ b/requests_toolbelt/_compat.py
@@ -8,6 +8,8 @@ urllib3 without providing a shim.
     This module is private. If you use it, and something breaks, you were
     warned
 """
+import sys
+
 
 try:
     from requests.packages.urllib3 import connection
@@ -19,3 +21,11 @@ except ImportError:
     from urllib3 import fields  # NOQA
     from urllib3 import filepost  # NOQA
     from urllib3 import poolmanager  # NOQA
+
+# Python version specific names
+is_py2 = (sys.version_info[0] == 2)
+
+if is_py2:
+    basestring = basestring
+else:
+    basestring = (str, bytes)

--- a/requests_toolbelt/_compat.py
+++ b/requests_toolbelt/_compat.py
@@ -8,24 +8,28 @@ urllib3 without providing a shim.
     This module is private. If you use it, and something breaks, you were
     warned
 """
-import sys
-
-
 try:
     from requests.packages.urllib3 import connection
     from requests.packages.urllib3 import fields
     from requests.packages.urllib3 import filepost
     from requests.packages.urllib3 import poolmanager
 except ImportError:
-    from urllib3 import connection  # NOQA
-    from urllib3 import fields  # NOQA
-    from urllib3 import filepost  # NOQA
-    from urllib3 import poolmanager  # NOQA
+    from urllib3 import connection
+    from urllib3 import fields
+    from urllib3 import filepost
+    from urllib3 import poolmanager
 
-# Python version specific names
-is_py2 = (sys.version_info[0] == 2)
 
-if is_py2:
+try:
     basestring = basestring
-else:
+except NameError:
     basestring = (str, bytes)
+
+
+__all__ = (
+    'basestring',
+    'connection',
+    'fields',
+    'filepost',
+    'poolmanager',
+)

--- a/requests_toolbelt/adapters/source.py
+++ b/requests_toolbelt/adapters/source.py
@@ -8,7 +8,7 @@ demonstrated on the Requests GitHub page.
 """
 from requests.adapters import HTTPAdapter
 
-from .._compat import poolmanager
+from .._compat import poolmanager, basestring
 
 
 class SourceAddressAdapter(HTTPAdapter):

--- a/requests_toolbelt/adapters/source.py
+++ b/requests_toolbelt/adapters/source.py
@@ -30,8 +30,12 @@ class SourceAddressAdapter(HTTPAdapter):
     def __init__(self, source_address, **kwargs):
         if isinstance(source_address, basestring):
             self.source_address = (source_address, 0)
-        else:
+        elif isinstance(source_address, tuple):
             self.source_address = source_address
+        else:
+            raise TypeError(
+                "source_address must be IP address string or (ip, port) tuple"
+            )
 
         super(SourceAddressAdapter, self).__init__(**kwargs)
 

--- a/requests_toolbelt/adapters/source.py
+++ b/requests_toolbelt/adapters/source.py
@@ -28,7 +28,10 @@ class SourceAddressAdapter(HTTPAdapter):
         s.mount('http://', SourceAddressAdapter('10.10.10.10'))
     """
     def __init__(self, source_address, **kwargs):
-        self.source_address = source_address
+        if isinstance(source_address, basestring):
+            self.source_address = (source_address, 0)
+        else:
+            self.source_address = source_address
 
         super(SourceAddressAdapter, self).__init__(**kwargs)
 

--- a/requests_toolbelt/adapters/source.py
+++ b/requests_toolbelt/adapters/source.py
@@ -17,6 +17,20 @@ class SourceAddressAdapter(HTTPAdapter):
     local address to bind to. This allows you to send your HTTP requests from a
     specific interface and IP address.
 
+    Two address formats are accepted. The first is a string: this will set the
+    local IP address to the address given in the string, and will also choose a
+    semi-random high port for the local port number.
+
+    The second is a two-tuple of the form (ip address, port): for example,
+    ``('10.10.10.10', 8999)``. This will set the local IP address to the first
+    element, and the local port to the second element. If ``0`` is used as the
+    port number, a semi-random high port will be selected.
+
+    .. warning:: Setting an explicit local port can have negative interactions
+                 with connection-pooling in Requests: in particular, it risks
+                 the possibility of getting "Address in use" errors. The
+                 string-only argument is generally preferred to the tuple-form.
+
     Example usage:
 
     .. code-block:: python
@@ -26,6 +40,7 @@ class SourceAddressAdapter(HTTPAdapter):
 
         s = requests.Session()
         s.mount('http://', SourceAddressAdapter('10.10.10.10'))
+        s.mount('https://', SourceAddressAdapter(('10.10.10.10', 8999))
     """
     def __init__(self, source_address, **kwargs):
         if isinstance(source_address, basestring):

--- a/tests/test_source_adapter.py
+++ b/tests/test_source_adapter.py
@@ -3,6 +3,8 @@ from requests.adapters import DEFAULT_POOLSIZE, DEFAULT_POOLBLOCK
 from mock import patch
 from requests_toolbelt.adapters.source import SourceAddressAdapter
 
+import pytest
+
 
 @patch('requests_toolbelt.adapters.source.poolmanager')
 def test_source_address_adapter_string(poolmanager):
@@ -26,3 +28,9 @@ def test_source_address_adapter_tuple(poolmanager):
         block=DEFAULT_POOLBLOCK,
         source_address=('10.10.10.10', 80)
     )
+
+
+@patch('requests_toolbelt.adapters.source.poolmanager')
+def test_source_address_adapter_type_error(poolmanager):
+    with pytest.raises(TypeError):
+        SourceAddressAdapter({'10.10.10.10': 80})

--- a/tests/test_source_adapter.py
+++ b/tests/test_source_adapter.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from requests.adapters import DEFAULT_POOLSIZE, DEFAULT_POOLBLOCK
+from mock import patch
+from requests_toolbelt.adapters.source import SourceAddressAdapter
+
+
+@patch('requests_toolbelt.adapters.source.poolmanager')
+def test_source_address_adapter_string(poolmanager):
+    SourceAddressAdapter('10.10.10.10')
+
+    poolmanager.PoolManager.assert_called_once_with(
+        num_pools=DEFAULT_POOLSIZE,
+        maxsize=DEFAULT_POOLSIZE,
+        block=DEFAULT_POOLBLOCK,
+        source_address=('10.10.10.10', 0)
+    )
+
+
+@patch('requests_toolbelt.adapters.source.poolmanager')
+def test_source_address_adapter_tuple(poolmanager):
+    SourceAddressAdapter(('10.10.10.10', 80))
+
+    poolmanager.PoolManager.assert_called_once_with(
+        num_pools=DEFAULT_POOLSIZE,
+        maxsize=DEFAULT_POOLSIZE,
+        block=DEFAULT_POOLBLOCK,
+        source_address=('10.10.10.10', 80)
+    )

--- a/tests/test_source_adapter.py
+++ b/tests/test_source_adapter.py
@@ -34,3 +34,5 @@ def test_source_address_adapter_tuple(poolmanager):
 def test_source_address_adapter_type_error(poolmanager):
     with pytest.raises(TypeError):
         SourceAddressAdapter({'10.10.10.10': 80})
+
+    assert not poolmanager.PoolManager.called


### PR DESCRIPTION
Resolves #96.

I'm a bit sad that this adapter has no test coverage, but it's a massive PITA to test effectively. I can write tests that are platform specific, but doing anything else is a huge pain. =(