### PR TITLE
Add a new parameter to user_agent generator

### DIFF
--- a/docs/user-agent.rst
+++ b/docs/user-agent.rst
@@ -28,3 +28,31 @@ into your program like this::
 
 This will override the default Requests user-agent string for all of your HTTP
 requests, replacing it with your own.
+
+Adding Extra Information to Your User-Agent String
+--------------------------------------------------
+
+.. versionadded:: 0.5.0
+
+If you feel it necessary, you can also include versions for other things that
+your client is using. For example if you were building a package and wanted to
+include the package name and version number as well as the version of requests
+and requests-toolbelt you were using you could do the following:
+
+.. code-block:: python
+
+    import requests
+    import requests_toolbelt
+    from requests_toolbelt.utils.user_agent import user_agent as ua
+
+    user_agent = ua.user_agent('mypackage', '0.0.1',
+                               extras=[('requests', requests.__version__),
+                                       ('requests-toolbelt', requests_toolbelt.__version__)])
+
+    s = requests.Session()
+    s.headers['User-Agent'] = user_agent
+
+
+Your user agent will now look like::
+
+    mypackage/0.0.1 requests/2.7.0 requests-toolbelt/0.5.0 CPython/2.7.10 Darwin/13.0.0

--- a/requests_toolbelt/utils/user_agent.py
+++ b/requests_toolbelt/utils/user_agent.py
@@ -3,7 +3,7 @@ import platform
 import sys
 
 
-def user_agent(name, version):
+def user_agent(name, version, extras=None):
     """
     Returns an internet-friendly user_agent string.
 
@@ -12,6 +12,10 @@ def user_agent(name, version):
 
     :param name: The intended name of the user-agent, e.g. "python-requests".
     :param version: The version of the user-agent, e.g. "0.0.1".
+    :param extras: List of two-item tuples that are added to the user-agent
+        string.
+    :returns: Formatted user-agent string
+    :rtype: str
     """
     try:
         p_system = platform.system()
@@ -20,9 +24,24 @@ def user_agent(name, version):
         p_system = 'Unknown'
         p_release = 'Unknown'
 
-    return " ".join(['%s/%s' % (name, version),
-                     _implementation_string(),
-                     '%s/%s' % (p_system, p_release)])
+    if extras is None:
+        extras = []
+
+    if any(len(extra) != 2 for extra in extras):
+        raise ValueError('Extras should be a sequence of two item tuples.')
+
+    format_string = '%s/%s'
+
+    extra_pieces = [
+        format_string % (extra_name, extra_version)
+        for extra_name, extra_version in extras
+    ]
+
+    user_agent_pieces = ([format_string % (name, version)] + extra_pieces +
+                         [_implementation_string(),
+                          '%s/%s' % (p_system, p_release)])
+
+    return " ".join(user_agent_pieces)
 
 
 def _implementation_string():

--- a/tests/test_user_agent.py
+++ b/tests/test_user_agent.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 import unittest
 import sys
+
 from mock import patch
+import pytest
+
 from requests_toolbelt.utils import user_agent as ua
 
 
@@ -18,6 +21,22 @@ class TestUserAgent(unittest.TestCase):
 
     def test_user_agent_provides_package_version(self):
         assert "0.0.1" in ua.user_agent("my-package", "0.0.1")
+
+    def test_user_agent_builds_extras_appropriately(self):
+        assert "extra/1.0.0" in ua.user_agent(
+            "my-package", "0.0.1", extras=[("extra", "1.0.0")]
+        )
+
+    def test_user_agent_checks_extras_for_tuples_of_incorrect_length(self):
+        with pytest.raises(ValueError):
+            ua.user_agent("my-package", "0.0.1", extras=[
+                ("extra", "1.0.0", "oops")
+            ])
+
+        with pytest.raises(ValueError):
+            ua.user_agent("my-package", "0.0.1", extras=[
+                ("extra",)
+            ])
 
 
 class TestImplementationString(unittest.TestCase):


### PR DESCRIPTION
This adds the extras parameter to the user_agent function in
requests_toolbelt.util.user_agent. As documented, this allows a user to
specify extra information to include in the User-Agent string.

Closes #162