### PR TITLE
Update progress bar example to use new len property

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -31,3 +31,5 @@ Patches and Suggestions
 - Markus Unterwaditzer <markus@unterwaditzer.net>
 
 - Bryce Boe <bbzbryce@gmail.com> (@bboe)
+
+- Dan Lipsitt (https://github.com/DanLipsitt)

--- a/examples/monitor/progress_bar.py
+++ b/examples/monitor/progress_bar.py
@@ -12,7 +12,7 @@ import requests
 
 
 def create_callback(encoder):
-    encoder_len = len(encoder)
+    encoder_len = encoder.len
     bar = ProgressBar(expected_size=encoder_len, filled_char='=')
 
     def callback(monitor):


### PR DESCRIPTION
MultipartEncoder.__len__() no longer exists. Use MultipartEncoder.len instead.

Closes #105