### PR TITLE
Add AppEngineAdapter for GAE users

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,40 @@
 History
 =======
 
+0.6.0 -- 2016-xx-yy
+-------------------
+
+More information about this release can be found on the `0.6.0 milestone`_.
+
+New Features
+~~~~~~~~~~~~
+
+- Add ``AppEngineAdapter`` to support developers using Google's AppEngine
+  platform with Requests.
+
+- Add ``GuessProxyAuth`` class to support guessing between Basic and Digest
+  Authentication for proxies.
+
+Fixed Bugs
+~~~~~~~~~~
+
+- Ensure that proxies use the correct TLS version when using the
+  ``SSLAdapter``.
+
+- Fix an ``AttributeError`` when using the ``HTTPProxyDigestAuth`` class.
+
+Miscellaneous
+~~~~~~~~~~~~~
+
+- Drop testing support for Python 3.2. virtualenv and pip have stopped
+  supporting it meaning that it is harder to test for this with our CI
+  infrastructure. Moving forward we will make a best-effort attempt to
+  support 3.2 but will not test for it.
+
+
+.. _0.6.0 milestone:
+    https://github.com/sigmavirus24/requests-toolbelt/milestones/0.6.0
+
 0.5.1 -- 2015-12-16
 -------------------
 

--- a/docs/adapters.rst
+++ b/docs/adapters.rst
@@ -7,6 +7,8 @@ The toolbelt comes with several different transport adapters for you to use
 with requests. The transport adapters are all kept in
 :mod:`requests_toolbelt.adapters` and include
 
+- :class:`requests_toolbelt.adapters.appengine.AppEngineAdapter`
+
 - :class:`requests_toolbelt.adapters.fingerprint.FingerprintAdapter`
 
 - :class:`requests_toolbelt.adapters.socket_options.SocketOptionsAdapter`
@@ -16,6 +18,40 @@ with requests. The transport adapters are all kept in
 - :class:`requests_toolbelt.adapters.source.SourceAddressAdapter`
 
 - :class:`requests_toolbelt.adapters.ssl.SSLAdapter`
+
+AppEngineAdapter
+----------------
+
+.. versionadded:: 0.6.0
+
+As of version 2.10.0, Requests will be capable of supporting Google's App
+Engine platform. In order to use Requests on GAE, however, you will need a
+custome adapter found here as
+:class:`~requests_toolbelt.adapters.appengine.AppEngineAdapter`. There are two
+ways to take advantage of this support at the moment:
+
+#. Using the :class:`~requests_toolbelt.adapters.appengine.AppEngineAdapter`
+   like every other adapter, e.g.,
+
+   .. code-block:: python
+
+       import requests
+       from requests_toolbelt.adapters import appengine
+
+       s = requests.Session()
+       s.mount('http://', appengine.AppEngineAdapter())
+       s.mount('https://', appengine.AppEngineAdapter())
+
+#. By monkey-patching requests to always use the provided adapter:
+
+   .. code-block:: python
+
+       import requests
+       from requests_toolbelt.adapters import appengine
+
+       appengine.monkeypatch()
+
+.. autoclass:: requests_toolbelt.adapters.appengine.AppEngineAdapter
 
 FingerprintAdapter
 ------------------

--- a/requests_toolbelt/_compat.py
+++ b/requests_toolbelt/_compat.py
@@ -11,6 +11,8 @@ urllib3 without providing a shim.
 from collections import Mapping, MutableMapping
 import sys
 
+import requests
+
 try:
     from requests.packages.urllib3 import connection
     from requests.packages.urllib3 import fields
@@ -21,6 +23,14 @@ except ImportError:
     from urllib3 import fields
     from urllib3 import filepost
     from urllib3 import poolmanager
+
+if requests.__build__ < 0x020800:
+    gaecontrib = None
+else:
+    try:
+        from requests.packages.urllib3.contrib import appengine as gaecontrib
+    except ImportError:
+        from urllib3.contrib import appengine as gaecontrib
 
 PY3 = sys.version_info > (3, 0)
 
@@ -275,4 +285,5 @@ __all__ = (
     'HTTPHeaderDict',
     'queue',
     'urlencode',
+    'gaecontrib',
 )

--- a/requests_toolbelt/adapters/appengine.py
+++ b/requests_toolbelt/adapters/appengine.py
@@ -32,7 +32,7 @@ class AppEngineAdapter(adapters.HTTPAdapter):
         >>>
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, validate_certificate=True, *args, **kwargs):
         if gaecontrib is None:
             raise exc.VersionMismatchError(
                 "The toolbelt requires at least Requests 2.8.0 to be "
@@ -40,11 +40,10 @@ class AppEngineAdapter(adapters.HTTPAdapter):
                     requests.__version__
                 )
             )
+        self._validate_certificate = validate_certificate
         super(AppEngineAdapter, self).__init__(self, *args, **kwargs)
 
     def init_poolmanager(self, connections, maxsize, block=False):
         self.poolmanager = gaecontrib.AppEngineManager(
-            num_pools=connections,
-            maxsize=maxsize,
-            block=block,
-            )
+            validate_certificate=self._validate_certificate
+        )

--- a/requests_toolbelt/adapters/appengine.py
+++ b/requests_toolbelt/adapters/appengine.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+"""The App Engine Transport Adapter for requests.
+
+This requires a version of requests >= 2.8.0.
+"""
+import requests
+from requests import adapters
+
+from .. import exceptions as exc
+from .._compat import gaecontrib
+
+
+class AppEngineAdapter(adapters.HTTPAdapter):
+    """A transport adapter for Requests to use urllib3's GAE support.
+
+    When deploying to Google's App Engine service, some of Requests'
+    functionality is broken. There is underlying support for GAE in urllib3.
+    This functionality, however, is opt-in and needs to be enabled explicitly
+    for Requests to be able to use it.
+
+    Example usage:
+
+    .. code-block:: python
+
+        >>> import requests
+        >>> import ssl
+        >>> from requests_toolbelt.adapters import appengine
+        >>> s = requests.Session()
+        >>> if using_appengine():
+        ...    s.mount('https://', appengine.AppEngineAdapter())
+        ...
+        >>>
+    """
+
+    def __init__(self, *args, **kwargs):
+        if gaecontrib is None:
+            raise exc.VersionMismatchError(
+                "The toolbelt requires at least Requests 2.8.0 to be "
+                "installed. Version {0} was found instead.".format(
+                    requests.__version__
+                )
+            )
+        super(AppEngineAdapter, self).__init__(self, *args, **kwargs)
+
+    def init_poolmanager(self, connections, maxsize, block=False):
+        self.poolmanager = gaecontrib.AppEngineManager(
+            num_pools=connections,
+            maxsize=maxsize,
+            block=block,
+            )

--- a/requests_toolbelt/exceptions.py
+++ b/requests_toolbelt/exceptions.py
@@ -5,3 +5,12 @@
 class StreamingError(Exception):
     """Used in :mod:`requests_toolbelt.downloadutils.stream`."""
     pass
+
+
+class VersionMismatchError(Exception):
+    """Used to indicate a version mismatch in the version of requests required.
+
+    The feature in use requires a newer version of Requests to function
+    appropriately but the version installed is not sufficient.
+    """
+    pass


### PR DESCRIPTION
At the moment this will not work because the AppEngineManager does not
have the same signature as urllib3's PoolManager.

Related to:
https://github.com/kennethreitz/requests/issues/1905#issuecomment-159380704

cc @Lukasa @shazow @jonparrott @webmaven @jacobg