### PR TITLE
Ensure proxies use correct TLS version.

### DIFF
--- a/requests_toolbelt/adapters/ssl.py
+++ b/requests_toolbelt/adapters/ssl.py
@@ -48,3 +48,7 @@ class SSLAdapter(HTTPAdapter):
             maxsize=maxsize,
             block=block,
             ssl_version=self.ssl_version)
+
+    def proxy_manager_for(self, *args, **kwargs):
+        kwargs['ssl_version'] = self.ssl_version
+        return super(SSLAdapter, self).proxy_manager_for(*args, **kwargs)

--- a/requests_toolbelt/adapters/ssl.py
+++ b/requests_toolbelt/adapters/ssl.py
@@ -9,6 +9,8 @@ in this blog post:
 https://lukasa.co.uk/2013/01/Choosing_SSL_Version_In_Requests/
 
 """
+import requests
+
 from requests.adapters import HTTPAdapter
 
 from .._compat import poolmanager
@@ -55,6 +57,10 @@ class SSLAdapter(HTTPAdapter):
             block=block,
             ssl_version=self.ssl_version)
 
-    def proxy_manager_for(self, *args, **kwargs):
-        kwargs['ssl_version'] = self.ssl_version
-        return super(SSLAdapter, self).proxy_manager_for(*args, **kwargs)
+    if requests.__build__ >= 0x020400:
+        # Earlier versions of requests either don't have this method or, worse,
+        # don't allow passing arbitrary keyword arguments. As a result, only
+        # conditionally define this method.
+        def proxy_manager_for(self, *args, **kwargs):
+            kwargs['ssl_version'] = self.ssl_version
+            return super(SSLAdapter, self).proxy_manager_for(*args, **kwargs)

--- a/requests_toolbelt/adapters/ssl.py
+++ b/requests_toolbelt/adapters/ssl.py
@@ -33,6 +33,12 @@ class SSLAdapter(HTTPAdapter):
     You can replace the chosen protocol with any that are available in the
     default Python SSL module. All subsequent requests that match the adapter
     prefix will use the chosen SSL version instead of the default.
+
+    This adapter will also attempt to change the SSL/TLS version negotiated by
+    Requests when using a proxy. However, this may not always be possible:
+    prior to Requests v2.4.0 the adapter did not have access to the proxy setup
+    code. In earlier versions of Requests, this adapter will not function
+    properly when used with proxies.
     """
 
     __attrs__ = HTTPAdapter.__attrs__ + ['ssl_version']

--- a/tests/test_ssladapter.py
+++ b/tests/test_ssladapter.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 import mock
+import os
+import pytest
 import requests
 import unittest
 
@@ -18,6 +20,8 @@ class TestSSLAdapter(unittest.TestCase):
             r = self.session.get('https://klevas.vu.lt/')
             assert r.status_code == 200
 
+    @pytest.mark.skipif(requests.__build__ < 0x020400,
+                        reason="Requires Requests v2.4.0 or later")
     @mock.patch('requests.packages.urllib3.poolmanager.ProxyManager')
     def test_proxies(self, ProxyManager):
         a = SSLAdapter('SSLv3')

--- a/tests/test_ssladapter.py
+++ b/tests/test_ssladapter.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import mock
 import requests
 import unittest
 
@@ -16,3 +17,12 @@ class TestSSLAdapter(unittest.TestCase):
         with self.recorder.use_cassette('klevas_vu_lt_ssl3'):
             r = self.session.get('https://klevas.vu.lt/')
             assert r.status_code == 200
+
+    @mock.patch('requests.packages.urllib3.poolmanager.ProxyManager')
+    def test_proxies(self, ProxyManager):
+        a = SSLAdapter('SSLv3')
+        a.proxy_manager_for('http://127.0.0.1:8888')
+
+        assert ProxyManager.call_count == 1
+        kwargs = ProxyManager.call_args_list[0][1]
+        assert kwargs['ssl_version'] == 'SSLv3'

--- a/tests/test_ssladapter.py
+++ b/tests/test_ssladapter.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import mock
-import os
 import pytest
 import requests
 import unittest


### PR DESCRIPTION
Credit for this work goes to [Quovo](https://www.quovo.com).

In the process of investigating a bug, I discovered that proxies take a different code path through the adapter: specifically, they don't use the poolmanager initiated via `init_poolmanager`, but instead use the `proxy_manager_for` function to build themselves a new ProxyManager. This meant they didn't get the correct TLS version from the `SSLAdapter`, and could lead to mysterious discrepancies between the with-and-without proxy case.

This change rectifies that problem.

@sigmavirus24 I'm not really sure how to test this with Betamax. Thoughts?