### PR TITLE
Fix AttributeError in HTTPProxyDigestAuth

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -35,3 +35,6 @@ Patches and Suggestions
 - Dan Lipsitt (https://github.com/DanLipsitt)
 
 - Cea Stapleton (http://www.ceastapleton.com)
+
+- Patrick Creech <pcreech@redhat.com>
+

--- a/requests_toolbelt/auth/http_proxy_digest.py
+++ b/requests_toolbelt/auth/http_proxy_digest.py
@@ -2,7 +2,7 @@
 """The module containing HTTPProxyDigestAuth."""
 import re
 
-from requests import cookies
+from requests import cookies, utils
 
 from . import _digest_auth_compat as auth
 
@@ -57,7 +57,7 @@ class HTTPProxyDigestAuth(auth.HTTPDigestAuth):
                 raise IOError(
                     "proxy server violated RFC 7235:"
                     "407 response MUST contain header proxy-authenticate")
-            self.chal = cookies.parse_dict_header(
+            self.chal = utils.parse_dict_header(
                 self._pat.sub('', r.headers['proxy-authenticate'], count=1))
 
             # if we present the user/passwd and still get rejected


### PR DESCRIPTION
parse_dict_header is in utils, not cookies.  This causes an
AttributeError in HTTPProxyDigestAuth.

Closes #122