### PR TITLE
Update supported versions of Python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,24 +11,12 @@ notifications:
 
 matrix:
   include:
-  - python: 2.6
-    env: TOXENV=py26
-  - python: 2.6
-    env: TOXENV=py26 REQUESTS_VERSION="===2.2.1"
-  - python: 2.6
-    env: TOXENV=py26 REQUESTS_VERSION="===2.1.0"
   - python: 2.7
     env: TOXENV=py27
   - python: 2.7
     env: TOXENV=py27 REQUESTS_VERSION="===2.2.1"
   - python: 2.7
     env: TOXENV=py27 REQUESTS_VERSION="===2.1.0"
-  - python: 3.2
-    env: TOXENV=py32
-  - python: 3.2
-    env: TOXENV=py32 REQUESTS_VERSION="===2.2.1"
-  - python: 3.2
-    env: TOXENV=py32 REQUESTS_VERSION="===2.1.0"
   - python: 3.3
     env: TOXENV=py33
   - python: 3.3

--- a/setup.py
+++ b/setup.py
@@ -58,11 +58,11 @@ setup(
         'Intended Audience :: Developers',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: Implementation :: CPython',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py32,py33,py34,pypy,{py27,py34}-flake8,docstrings
+envlist = py27,py33,py34,py35,pypy,{py27,py34}-flake8,docstrings
 
 [testenv]
 pip_pre = False


### PR DESCRIPTION
pip dropped support for 3.2 and 2.6 usage is very low according to PyPI