### PR TITLE
Don't actually allow pip to install Requests 3.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     packages=packages,
     package_data={'': ['LICENSE', 'AUTHORS.rst']},
     include_package_data=True,
-    install_requires=['requests>=2.0.1,<=3.0.0'],
+    install_requires=['requests>=2.0.1,<3.0.0'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'License :: OSI Approved :: Apache Software License',


### PR DESCRIPTION
I assume that this max-version was introduced because Requests 3 could
break requests-toolbelt.