### PR TITLE
Improvements to stream_response_to_file()

### DIFF
--- a/requests_toolbelt/downloadutils/stream.py
+++ b/requests_toolbelt/downloadutils/stream.py
@@ -12,6 +12,7 @@ _OPTION_HEADER_PIECE_RE = re.compile(
     r';\s*(%s|[^\s;=]+)\s*(?:=\s*(%s|[^;]+))?\s*' % (_QUOTED_STRING_RE,
                                                      _QUOTED_STRING_RE)
 )
+_DEFAULT_CHUNKSIZE = 512
 
 
 def _get_filename(content_disposition):
@@ -22,7 +23,7 @@ def _get_filename(content_disposition):
     return None
 
 
-def stream_response_to_file(response, path=None):
+def stream_response_to_file(response, path=None, chunksize=_DEFAULT_CHUNKSIZE):
     """Stream a response body to the specified file.
 
     Either use the ``path`` provided or use the name provided in the
@@ -93,12 +94,12 @@ def stream_response_to_file(response, path=None):
         filename = stream.stream_response_to_file(r, path=b)
         assert filename is None
 
-
     :param response: A Response object from requests
     :type response: requests.models.Response
     :param path: *(optional)*, Either a string with the path to the location
         to save the response content, or a file-like object expecting bytes.
     :type path: :class:`str`, or object with a :meth:`write`
+    :param int chunksize: (optional), Size of chunk to attempt to stream (default 512B).
     :returns: The name of the file, if one can be determined, else None
     :rtype: str
     :raises: :class:`requests_toolbelt.exceptions.StreamingError`
@@ -122,7 +123,7 @@ def stream_response_to_file(response, path=None):
             )
         fd = open(filename, 'wb')
 
-    for chunk in response.iter_content(chunk_size=512):
+    for chunk in response.iter_content(chunk_size=chunksize):
         fd.write(chunk)
 
     if not pre_opened:

--- a/tests/test_downloadutils.py
+++ b/tests/test_downloadutils.py
@@ -104,6 +104,28 @@ def test_stream_response_to_directory():
         shutil.rmtree(td)
 
 
+def test_stream_response_to_existing_file():
+    s = requests.Session()
+    recorder = get_betamax(s)
+    url = ('https://api.github.com/repos/sigmavirus24/github3.py/releases/'
+           'assets/37944')
+    filename = 'github3.py.whl'
+    with open(filename, 'w') as f_existing:
+        f_existing.write('test')
+
+    with recorder.use_cassette('stream_response_to_file', **preserve_bytes):
+        r = s.get(url, headers={'Accept': 'application/octet-stream'},
+                  stream=True)
+    try:
+        stream.stream_response_to_file(r, path=filename)
+    except stream.exc.StreamingError as e:
+        assert str(e).startswith('File already exists:')
+    else:
+        assert False, "Should have raised a FileExistsError"
+    finally:
+        os.unlink(filename)
+
+
 def test_stream_response_to_file_like_object():
     s = requests.Session()
     recorder = get_betamax(s)


### PR DESCRIPTION
Problem: API client library saving large responses via `requests_toolbelt.downloadutils.stream.stream_response_to_file()` wants to enable simple progress reporting via a callback.

Changes:

1. ~~add `callback` parameter to `stream_response_to_file()`, which is a function that takes two arguments `(bytes_read, total_bytes)`. The function will be called at least twice (at 0 bytes and at the end). `total_bytes` can be `None` if there's no `Content-Length` header on the response.~~
2. add optional `chunksize` parameter to `stream_response_to_file()`, ~~and increase the default chunk size from 512 bytes to 64KB. This matches the chunk size used in `dowloadutils.tee`. This should improve performance significantly for large responses.~~
3. extract the filename/header/file-object parsing into a separate function
4. add support for passing a directory to save into using the Content-Disposition filename (rather than always using the current working directory)
5. only use the last file-part of Content-Disposition headers: eg. `Content-Disposition: attachment; filename=/etc/passwd`
6. prevent overwriting existing files using arbitrary filenames from the server. This is obviously backwards incompatible for apps that expect to overwrite the same file every time.

* [x] Tests
* [x] Docs