### PR TITLE
Include RTD theme for Sphinx 1.4.0+

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -99,9 +99,15 @@ pygments_style = 'sphinx'
 
 # -- Options for HTML output ----------------------------------------------
 
+on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+if not on_rtd:  # only import and set the theme if we're building docs locally
+    import sphinx_rtd_theme
+    html_theme = 'sphinx_rtd_theme'
+    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'sphinx_rtd_theme'
+#html_theme = 'alabaster'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,7 @@ commands = flake8 {posargs} requests_toolbelt
 [testenv:docs]
 deps =
     sphinx>=1.3.0
+    sphinx_rtd_theme
     .
 commands =
     sphinx-build -E -c docs -b html docs/ docs/_build/html


### PR DESCRIPTION
With Sphinx 1.4, the RTD theme became optional, and needs to be included as a dependency in `tox.ini`

Otherwise when you run `tox -e docs` you get:
```
...
docs runtests: commands[0] | sphinx-build -E -c docs -b html docs/ docs/_build/html
Running Sphinx v1.4.1

Theme error:
sphinx_rtd_theme is no longer a hard dependency since version 1.4.0. Please install it manually.
ERROR: InvocationError: '/Users/rcoup/code/requests-toolbelt/.tox/docs/bin/sphinx-build -E -c docs -b html docs/ docs/_build/html'
______________________________________________________________________________________ summary ______________________________________________________________________________________
ERROR:   docs: commands failed
```