### PR TITLE
Add pip install note

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,8 @@ really belong in ``requests`` proper. The minimum tested requests version is
 ``2.1.0``. In reality, the toolbelt should work with ``2.0.1`` as well, but 
 some idiosyncracies prevent effective or sane testing on that version.
 
+``pip install requests-toolbelt`` to get started!
+
 
 multipart/form-data Encoder
 ---------------------------


### PR DESCRIPTION
Because otherwise the only place this is stated is in the `setup.py`.