### PR TITLE
App Engine: set total timeout so urllib3 passes it to urlfetch

### DIFF
--- a/requests_toolbelt/adapters/appengine.py
+++ b/requests_toolbelt/adapters/appengine.py
@@ -100,6 +100,11 @@ class _AppEngineConnection(object):
         # We once tried to verify our assumptions here, but sometimes the
         # passed-in URL differs on url fragments, or "http://a.com" vs "/".
 
+        # urllib3's App Engine adapter only uses Timeout.total, not read or
+        # connect.
+        if not timeout.total:
+            timeout.total = timeout._read or timeout._connect
+
         # Jump through the hoops necessary to call AppEngineManager's API.
         return self.appengine_manager.urlopen(
             method,

--- a/tests/test_appengine_adapter.py
+++ b/tests/test_appengine_adapter.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+"""Tests for the AppEngineAdapter."""
+import sys
+
+import mock
+import pytest
+import requests
+
+REQUESTS_SUPPORTS_GAE = requests.__build__ >= 0x021000
+
+if REQUESTS_SUPPORTS_GAE:
+    from requests.packages.urllib3.contrib import appengine as urllib3_appengine
+    from requests_toolbelt.adapters import appengine
+else:
+    appengine = urllib3_appengine = None
+
+
+@pytest.mark.skipif(sys.version_info >= (3,),
+                    reason="App Engine doesn't support Python 3 (yet)")
+@pytest.mark.skipif(not REQUESTS_SUPPORTS_GAE,
+                    reason="Requires Requests v2.10.0 or later")
+@mock.patch.object(urllib3_appengine, 'urlfetch')
+def test_get(mock_urlfetch):
+    """Tests a simple requests.get() call.
+
+    App Engine urlfetch docs:
+    https://cloud.google.com/appengine/docs/python/refdocs/google.appengine.api.urlfetch
+    """
+    response = mock.Mock(status_code=200, content='asdf', headers={})
+    mock_urlfetch.fetch = mock.Mock(return_value=response)
+
+    session = requests.Session()
+    session.mount('http://', appengine.AppEngineAdapter())
+    resp = session.get('http://url/', timeout=9, headers={'Foo': 'bar'})
+    assert resp.status_code == 200
+    assert resp.content == 'asdf'
+
+    args, kwargs = mock_urlfetch.fetch.call_args
+    assert args == ('http://url/',)
+    assert kwargs['deadline'] == 9
+    assert kwargs['headers']['Foo'] == 'bar'


### PR DESCRIPTION
Closes #145.

Another plausibe alternative here would be to change [this line in urllib3's App Engine adapter](https://github.com/snarfed/urllib3/blob/3239c172b19e41f41777db4bd55daae40c99b43d/urllib3/contrib/appengine.py#L192) from `return timeout.total` to something like `return timeout.total or timeout._read or timeout._connect`. I'm not sure of the semantics or conventions for requests vs urllib3, so I'll defer to you all.

cc @mikelambert