### PR TITLE
Proxy support for SourceAddressAdapter

### DIFF
--- a/requests_toolbelt/adapters/source.py
+++ b/requests_toolbelt/adapters/source.py
@@ -63,4 +63,5 @@ class SourceAddressAdapter(HTTPAdapter):
 
     def proxy_manager_for(self, *args, **kwargs):
         kwargs['source_address'] = self.source_address
-        return super(SourceAddressAdapter, self).proxy_manager_for(*args, **kwargs)
+        return super(SourceAddressAdapter, self).proxy_manager_for(
+            *args, **kwargs)

--- a/requests_toolbelt/adapters/source.py
+++ b/requests_toolbelt/adapters/source.py
@@ -60,3 +60,7 @@ class SourceAddressAdapter(HTTPAdapter):
             maxsize=maxsize,
             block=block,
             source_address=self.source_address)
+
+    def proxy_manager_for(self, *args, **kwargs):
+        kwargs['source_address'] = self.source_address
+        return super(SourceAddressAdapter, self).proxy_manager_for(*args, **kwargs)


### PR DESCRIPTION
Using proxy_manager_for to pass source_address to the ProxyManager.