### PR TITLE
Fix incorrect import in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,7 +89,7 @@ cookies:
 
 .. code-block:: python
 
-    from requests-toolbelt.cookies import ForgetfulCookieJar
+    from requests_toolbelt.cookies.forgetful import ForgetfulCookieJar
 
     session = requests.Session()
     session.cookies = ForgetfulCookieJar()


### PR DESCRIPTION
If you do want `from requests_toolbelt.cookies import ForgetfulCookieJar` (with an underscore, not a dash) to work, then imports need to go in `requests_toolbelt/cookies/__init__.py`.