### PR TITLE
Allow users to access an IP address via HTTPS

### DIFF
--- a/docs/adapters.rst
+++ b/docs/adapters.rst
@@ -100,6 +100,46 @@ attempt to negotiate TLSv1, and hopefully will succeed.
 
 .. _here: https://lukasa.co.uk/2013/01/Choosing_SSL_Version_In_Requests/
 
+SNIAdapter
+----------
+
+The ``SNIAdapter`` allows the user to access the IP address directly via HTTPS.
+
+Normally, such a request fails with a "hostname doesn't match" exception:
+
+.. code-block:: python
+
+    >>> import requests
+    >>> requests.get(url="https://93.184.216.34", headers={"Host": "example.org"})
+    Traceback (most recent call last):
+      File "<stdin>", line 1, in <module>
+      File "[...]/requests/api.py", line 71, in get
+        return request('get', url, params=params, **kwargs)
+      File "[...]/requests/api.py", line 57, in request
+        return session.request(method=method, url=url, **kwargs)
+      File "[...]/requests/sessions.py", line 475, in request
+        resp = self.send(prep, **send_kwargs)
+      File "[...]/requests/sessions.py", line 585, in send
+        r = adapter.send(request, **kwargs)
+      File "[...]/requests/adapters.py", line 477, in send
+        raise SSLError(e, request=request)
+    requests.exceptions.SSLError: hostname '93.184.216.34' doesn't match either of 'www.example.org', 'example.com', 'example.edu', 'example.net', 'example.org', 'www.example.com', 'www.example.edu', 'www.example.net'
+
+Using the :class:`~requests_toolbelt.adapters.sni.SNIAdapter`, requests can
+verify the hostname successfully based on the explicitly set host header.
+
+Example usage:
+
+.. code-block:: python
+
+        import requests
+        from requests_toolbelt import SNIAdapter
+        s = requests.Session()
+        s.mount('https://', SNIAdapter())
+        s.get("https://93.184.216.34", headers={"Host": "example.org"})
+
+.. autoclass:: requests_toolbelt.adapters.sni.SNIAdapter
+
 SourceAddressAdapter
 --------------------
 

--- a/requests_toolbelt/__init__.py
+++ b/requests_toolbelt/__init__.py
@@ -9,7 +9,7 @@ See http://toolbelt.rtfd.org/ for documentation
 :license: Apache v2.0, see LICENSE for more details
 """
 
-from .adapters import SSLAdapter, SourceAddressAdapter
+from .adapters import SSLAdapter, SourceAddressAdapter, SNIAdapter
 from .auth.guess import GuessAuth
 from .multipart import (
     MultipartEncoder, MultipartEncoderMonitor, MultipartDecoder,
@@ -27,7 +27,7 @@ __version_info__ = tuple(int(i) for i in __version__.split('.'))
 
 __all__ = [
     'GuessAuth', 'MultipartEncoder', 'MultipartEncoderMonitor',
-    'MultipartDecoder', 'SSLAdapter', 'SourceAddressAdapter',
+    'MultipartDecoder', 'SSLAdapter', 'SourceAddressAdapter', 'SNIAdapter',
     'StreamingIterator', 'user_agent', 'ImproperBodyPartContentException',
     'NonMultipartContentTypeException', '__title__', '__authors__',
     '__license__', '__copyright__', '__version__', '__version_info__',

--- a/requests_toolbelt/adapters/__init__.py
+++ b/requests_toolbelt/adapters/__init__.py
@@ -11,5 +11,6 @@ See http://toolbelt.rtfd.org/ for documentation
 
 from .ssl import SSLAdapter
 from .source import SourceAddressAdapter
+from .sni import SNIAdapter
 
-__all__ = ['SSLAdapter', 'SourceAddressAdapter']
+__all__ = ['SSLAdapter', 'SourceAddressAdapter', 'SNIAdapter']

--- a/requests_toolbelt/adapters/sni.py
+++ b/requests_toolbelt/adapters/sni.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+"""
+requests_toolbelt.sni_adapter
+=============================
+
+This file contains an implementation of the SNIAdapter
+"""
+
+from requests.adapters import HTTPAdapter
+
+
+class SNIAdapter(HTTPAdapter):
+    """
+    A HTTPS Adapter for Python Requests that sets the hostname for certificate
+    verification based on the host header.
+
+    This allows requesting the IP address directly via HTTPS without getting
+    a "hostname doesn't match" exception.
+
+    Example usage:
+
+        >>> import requests
+        >>> from requests_toolbelt import SNIAdapter
+        >>> s = requests.Session()
+        >>> s.mount('https://', SNIAdapter())
+        >>> s.get("https://93.184.216.34", headers={"Host": "example.org"})
+
+    """
+
+    def send(self, request, **kwargs):
+
+        # HTTP headers are case-insensitive (RFC 7230)
+        host = None
+        for header in request.headers:
+            if header.lower() == "host":
+                host = request.headers[header]
+                break
+
+        if host:
+            self.poolmanager.connection_pool_kw["assert_hostname"] = host
+        elif "assert_hostname" in self.poolmanager.connection_pool_kw:
+            # an assert_hostname from a previous request may have been left
+            del self.poolmanager.connection_pool_kw["assert_hostname"]
+
+        return super(SNIAdapter, self).send(request, **kwargs)

--- a/tests/test_sniadapter.py
+++ b/tests/test_sniadapter.py
@@ -1,0 +1,46 @@
+import unittest
+import requests
+
+from requests_toolbelt import SNIAdapter
+
+
+class TestSNIAdapter(unittest.TestCase):
+
+    def setUp(self):
+        self.session = requests.Session()
+        self.session.mount("https://", SNIAdapter())
+
+    def test_sniadapter(self):
+        # normal mode
+        r = self.session.get("https://example.org")
+        assert r.status_code == 200
+
+        # accessing IP address directly
+        r = self.session.get("https://93.184.216.34",
+                             headers={"Host": "example.org"})
+        assert r.status_code == 200
+
+        # vHost
+        r = self.session.get("https://93.184.216.34",
+                             headers={"Host": "example.com"})
+        assert r.status_code == 200
+
+    def test_stream(self):
+        self.session.get("https://54.175.219.8/stream/20",
+                         headers={"Host": "httpbin.org"},
+                         stream=True)
+
+    def test_case_insensitive_header(self):
+        r = self.session.get("https://93.184.216.34",
+                             headers={"hOSt": "example.org"})
+        assert r.status_code == 200
+
+    def test_plain_requests(self):
+        # test whether the reason for this adapter remains
+        # (may be implemented into requests in the future)
+        with self.assertRaises(requests.exceptions.SSLError):
+            requests.get(url="https://93.184.216.34",
+                         headers={"Host": "example.org"})
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Requesting a IP address directly like this fails with an Exception:

    requests.get(url="https://93.184.216.34", headers={"Host": "example.org"})

SSL certificate verification doesn't respect the explicitly set host header
and fails with "hostname doesn't match".

This commit adds a SNIAdapter which sets the host name used for verification
based on the HTTP host header.

It can be used like so:

    from requests_toolbelt import SNIAdapter
    s = requests.Session()
    s.mount('https://', SNIAdapter())
    s.get("https://93.184.216.34", headers={"Host": "example.org"})

see: https://github.com/kennethreitz/requests/issues/3403