### PR TITLE
Disable cert validation when monkeypatching AppEngine

### DIFF
--- a/docs/adapters.rst
+++ b/docs/adapters.rst
@@ -53,6 +53,25 @@ ways to take advantage of this support at the moment:
 
        appengine.monkeypatch()
 
+If you should need to disable certification validation when monkeypatching (to
+force third-party libraries that use requests to not validate certificates, if
+they do not provide API surface to do so, for example), you can disable it:
+
+   .. code-block:: python
+
+       from requests_toolbelt.adapters import appengine
+       appengine.monkeypatch(validate_certificate=False)
+
+   .. warning::
+
+       If ``validate_certificate`` is ``False``, the monkeypatched adapter
+       will *not* validate certificates. This effectively sets the
+       ``validate_certificate`` argument to urlfetch.Fetch() to ``False``. You
+       should avoid using this wherever possible. Details can be found in the
+       `documentation for urlfetch.Fetch()`__.
+
+       __ https://cloud.google.com/appengine/docs/python/refdocs/google.appengine.api.urlfetch
+
 .. autoclass:: requests_toolbelt.adapters.appengine.AppEngineAdapter
 
 FingerprintAdapter

--- a/docs/adapters.rst
+++ b/docs/adapters.rst
@@ -53,6 +53,8 @@ ways to take advantage of this support at the moment:
 
        appengine.monkeypatch()
 
+.. _insecure_appengine:
+
 If you should need to disable certificate validation when monkeypatching (to
 force third-party libraries that use Requests to not validate certificates, if
 they do not provide API surface to do so, for example), you can disable it:
@@ -68,9 +70,9 @@ they do not provide API surface to do so, for example), you can disable it:
        will *not* validate certificates. This effectively sets the
        ``validate_certificate`` argument to urlfetch.Fetch() to ``False``. You
        should avoid using this wherever possible. Details can be found in the
-       `documentation for urlfetch.Fetch()`__.
+       `documentation for urlfetch.Fetch()`_.
 
-       __ https://cloud.google.com/appengine/docs/python/refdocs/google.appengine.api.urlfetch
+       .. _documentation for urlfetch.Fetch(): https://cloud.google.com/appengine/docs/python/refdocs/google.appengine.api.urlfetch
 
 .. autoclass:: requests_toolbelt.adapters.appengine.AppEngineAdapter
 
@@ -150,7 +152,7 @@ SourceAddressAdapter
 
 .. versionadded:: 0.3.0
 
-The :class:`~requests_toolbelt.adapters.source.SourceAddressAdapter` allows a 
+The :class:`~requests_toolbelt.adapters.source.SourceAddressAdapter` allows a
 user to specify a source address for their connnection.
 
 .. autoclass:: requests_toolbelt.adapters.source.SourceAddressAdapter

--- a/docs/adapters.rst
+++ b/docs/adapters.rst
@@ -53,8 +53,8 @@ ways to take advantage of this support at the moment:
 
        appengine.monkeypatch()
 
-If you should need to disable certification validation when monkeypatching (to
-force third-party libraries that use requests to not validate certificates, if
+If you should need to disable certificate validation when monkeypatching (to
+force third-party libraries that use Requests to not validate certificates, if
 they do not provide API surface to do so, for example), you can disable it:
 
    .. code-block:: python

--- a/requests_toolbelt/adapters/appengine.py
+++ b/requests_toolbelt/adapters/appengine.py
@@ -30,8 +30,8 @@ There are two ways to use this library:
 
 which will ensure all requests.Session objects use AppEngineAdapter properly.
 
-If you should need to disable certification validation when monkeypatching (to
-force third-party libraries that use requests to not validate certificates, if
+If you should need to disable certificate validation when monkeypatching (to
+force third-party libraries that use Requests to not validate certificates, if
 they do not provide API surface to do so, for example), you can disable it:
 
    .. code-block:: python

--- a/requests_toolbelt/adapters/appengine.py
+++ b/requests_toolbelt/adapters/appengine.py
@@ -47,7 +47,7 @@ they do not provide API surface to do so, for example), you can disable it:
        should avoid using this wherever possible. Details can be found in the
        `documentation for urlfetch.Fetch()`__.
 
-       __ https://cloud.google.com/appengine/docs/python/refdocs/google.appengine.api.urlfetch
+       __ https://cloud.google.com/appengine/docs/python/refdocs/google.appengine.api.urlfetch  # noqa
 """
 import requests
 from requests import adapters

--- a/requests_toolbelt/adapters/appengine.py
+++ b/requests_toolbelt/adapters/appengine.py
@@ -29,6 +29,25 @@ There are two ways to use this library:
        >>> appengine.monkeypatch()
 
 which will ensure all requests.Session objects use AppEngineAdapter properly.
+
+If you should need to disable certification validation when monkeypatching (to
+force third-party libraries that use requests to not validate certificates, if
+they do not provide API surface to do so, for example), you can disable it:
+
+   .. code-block:: python
+
+       >>> from requests_toolbelt.adapters import appengine
+       >>> appengine.monkeypatch(validate_certificate=False)
+
+   .. warning::
+
+       If ``validate_certificate`` is ``False``, the monkeypatched adapter
+       will *not* validate certificates. This effectively sets the
+       ``validate_certificate`` argument to urlfetch.Fetch() to ``False``. You
+       should avoid using this wherever possible. Details can be found in the
+       `documentation for urlfetch.Fetch()`__.
+
+       __ https://cloud.google.com/appengine/docs/python/refdocs/google.appengine.api.urlfetch
 """
 import requests
 from requests import adapters

--- a/requests_toolbelt/exceptions.py
+++ b/requests_toolbelt/exceptions.py
@@ -17,7 +17,7 @@ class VersionMismatchError(Exception):
 
 
 class RequestsVersionTooOld(Warning):
-    """Used to indiciate that the Requests version is too old.
+    """Used to indicate that the Requests version is too old.
 
     If the version of Requests is too old to support a feature, we will issue
     this warning to the user.
@@ -25,9 +25,12 @@ class RequestsVersionTooOld(Warning):
     pass
 
 
-class IgnoringCertificateValidation(Warning):
-    """Used to indiciate that the user has tried to specify certificate
-    validation but it will be ignored (validation will remain off).
+class IgnoringGAECertificateValidation(Warning):
+    """Used to indicate that given GAE validation behavior will be ignored.
+
+    If the user has tried to specify certificate validation when using the
+    insecure AppEngine adapter, it will be ignored (certificate validation will
+    remain off), so we will issue this warning to the user.
 
     In :class:`requests_toolbelt.adapters.appengine.InsecureAppEngineAdapter`.
     """

--- a/requests_toolbelt/exceptions.py
+++ b/requests_toolbelt/exceptions.py
@@ -23,3 +23,12 @@ class RequestsVersionTooOld(Warning):
     this warning to the user.
     """
     pass
+
+
+class IgnoringCertificateValidation(Warning):
+    """Used to indiciate that the user has tried to specify certificate
+    validation but it will be ignored (validation will remain off).
+
+    In :class:`requests_toolbelt.adapters.appengine.InsecureAppEngineAdapter`.
+    """
+    pass

--- a/tests/test_appengine_adapter.py
+++ b/tests/test_appengine_adapter.py
@@ -85,5 +85,5 @@ def test_insecure_appengine_adapter(mock_urlfetch):
 
     assert not adapter._validate_certificate
 
-    with pytest.warns(exc.IgnoringCertificateValidation):
+    with pytest.warns(exc.IgnoringGAECertificateValidation):
         adapter = appengine.InsecureAppEngineAdapter(validate_certificate=True)

--- a/tests/test_appengine_adapter.py
+++ b/tests/test_appengine_adapter.py
@@ -42,3 +42,45 @@ def test_get(mock_urlfetch):
     assert args == ('http://url/',)
     assert kwargs['deadline'] == 9
     assert kwargs['headers']['Foo'] == 'bar'
+
+
+@pytest.mark.skipif(sys.version_info >= (3,),
+                    reason="App Engine doesn't support Python 3 (yet) and "
+                           "urllib3's appengine contrib code is Python 2 "
+                           "only. Until the latter changes, this test will "
+                           "be skipped, unfortunately.")
+@pytest.mark.skipif(not REQUESTS_SUPPORTS_GAE,
+                    reason="Requires Requests v2.10.0 or later")
+def test_appengine_monkeypatch():
+    """Tests monkeypatching Requests adapters for AppEngine compatibility.
+    """
+    adapter = requests.sessions.HTTPAdapter
+
+    appengine.monkeypatch()
+
+    assert requests.sessions.HTTPAdapter == appengine.AppEngineAdapter
+    assert requests.adapters.HTTPAdapter == appengine.AppEngineAdapter
+
+    appengine.monkeypatch(validate_certificate=False)
+
+    assert requests.sessions.HTTPAdapter == appengine.InsecureAppEngineAdapter
+    assert requests.adapters.HTTPAdapter == appengine.InsecureAppEngineAdapter
+
+    requests.sessions.HTTPAdapter = adapter
+    requests.adapters.HTTPAdapter = adapter
+
+
+@pytest.mark.skipif(sys.version_info >= (3,),
+                    reason="App Engine doesn't support Python 3 (yet) and "
+                           "urllib3's appengine contrib code is Python 2 "
+                           "only. Until the latter changes, this test will "
+                           "be skipped, unfortunately.")
+@pytest.mark.skipif(not REQUESTS_SUPPORTS_GAE,
+                    reason="Requires Requests v2.10.0 or later")
+@mock.patch.object(urllib3_appeng, 'urlfetch')
+def test_insecure_appengine_adapter(mock_urlfetch):
+    adapter = appengine.InsecureAppEngineAdapter()
+
+    assert not adapter._validate_certificate
+
+    adapter = appengine.InsecureAppEngineAdapter(validate_certificate=True)

--- a/tests/test_appengine_adapter.py
+++ b/tests/test_appengine_adapter.py
@@ -6,6 +6,8 @@ import mock
 import pytest
 import requests
 
+from requests_toolbelt import exceptions as exc
+
 REQUESTS_SUPPORTS_GAE = requests.__build__ >= 0x021000
 
 if REQUESTS_SUPPORTS_GAE:
@@ -83,4 +85,5 @@ def test_insecure_appengine_adapter(mock_urlfetch):
 
     assert not adapter._validate_certificate
 
-    adapter = appengine.InsecureAppEngineAdapter(validate_certificate=True)
+    with pytest.warns(exc.IgnoringCertificateValidation):
+        adapter = appengine.InsecureAppEngineAdapter(validate_certificate=True)


### PR DESCRIPTION
We have a use case for this in which, due to an issue with AppEngine's `dev_appserver.py`, certain certificates will fail validation; more on that issue [here](https://code.google.com/p/googleappengine/issues/detail?id=13154). The only real workaround when using the emulator is to disable certificate validation.

Because this is a large code base, in which requests is used both explicitly and within third-party libraries, we are using the monkeypatch; however, to my eye there's no way to set the `validate_certificate` kwarg in the constructor for `AppEngineAdapter` to `True` when monkeypatching; if we could, it would serve our use case by allowing global disabling of certificate validation when a local environment is detected.

This creates a new `AppEngineInsecureAdapter` in which cert validation is disabled by default and adds a kwarg to `monkeypatch()` to trigger its use. Initially I tried to simply make the monkeypatch set `partial(AppEngineAdapter, validate_certificate=False)` but that was a bit naive as the adapter is not just instantiated.