### PR TITLE
AppEngine monkeypatching MRO fix

### DIFF
--- a/requests_toolbelt/adapters/appengine.py
+++ b/requests_toolbelt/adapters/appengine.py
@@ -52,11 +52,11 @@ class AppEngineMROHack(adapters.HTTPAdapter):
     monkeypatch, at which point this class becomes HTTPAdapter's base class.
     In addition, we use an instantiation flag to avoid infinite recursion.
     """
-    initialized = False
+    _initialized = False
 
     def __init__(self):
-        if not self.initialized:
-            self.initialized = True
+        if not self._initialized:
+            self._initialized = True
             super(AppEngineMROHack, self).__init__()
 
 


### PR DESCRIPTION
This works around some of the issues found in #169.

With my esteemed colleague @Bogdanp, we determined the issue that arises when monkeypatching is not actually the inheritance relationship set up between these classes, or the import aliasing; it's when the MRO is re-calculated for the monkeypatched class. This behavior can be reproduced with this trivial example:

```python
class Foo(object):
    def __init__(self):
        super(Foo, self).__init__()


class Bar(Foo):
    def __init__(self):
        super(Bar, self).__init__()


Foo = Bar
Bar()
```

The way @Bogdanp devised to work around this is to add an intermediate class that makes the MRO be calculated properly; there's some more detail in the docstring and commit around this.