### PR TITLE
Add UserAgentBuilder class

### DIFF
--- a/docs/user-agent.rst
+++ b/docs/user-agent.rst
@@ -43,7 +43,7 @@ and requests-toolbelt you were using you could do the following:
 
     import requests
     import requests_toolbelt
-    from requests_toolbelt.utils.user_agent import user_agent as ua
+    from requests_toolbelt.utils import user_agent as ua
 
     user_agent = ua.user_agent('mypackage', '0.0.1',
                                extras=[('requests', requests.__version__),
@@ -56,3 +56,39 @@ and requests-toolbelt you were using you could do the following:
 Your user agent will now look like::
 
     mypackage/0.0.1 requests/2.7.0 requests-toolbelt/0.5.0 CPython/2.7.10 Darwin/13.0.0
+
+Selecting Only What You Want
+----------------------------
+
+.. versionadded:: 0.8.0
+
+While most people will find the ``user_agent`` function sufficient for their
+usage, others will want to control exactly what information is included in the
+User-Agent. For those people, the
+:class:`~requests_toolbelt.utils.user_agent.UserAgentBuilder` is the correct
+tool. This is the tool that the toolbelt uses inside of
+:func:`~requests_toolbelt.utils.user_agent.user_agent`. For example, let's say
+you *only* want your package, its versions, and some extra information, in
+that case you would do:
+
+.. code-block:: python
+
+    import requests
+    from requests_toolbelt.utils import user_agent as ua
+
+    s = requests.Session()
+    s.headers['User-Agent'] = ua.UserAgentBuilder(
+            'mypackage', '0.0.1',
+        ).include_extras([
+            ('requests', requests.__version__),
+        ]).build()
+
+Your user agent will now look like::
+
+    mypackage/0.0.1 requests/2.7.0
+
+You can also optionally include the Python version information and System
+information the same way that our ``user_agent`` function does.
+
+.. autoclass:: requests_toolbelt.utils.user_agent.UserAgentBuilder
+    :members:

--- a/requests_toolbelt/__init__.py
+++ b/requests_toolbelt/__init__.py
@@ -22,7 +22,7 @@ __title__ = 'requests-toolbelt'
 __authors__ = 'Ian Cordasco, Cory Benfield'
 __license__ = 'Apache v2.0'
 __copyright__ = 'Copyright 2014 Ian Cordasco, Cory Benfield'
-__version__ = '0.7.1'
+__version__ = '0.8.0'
 __version_info__ = tuple(int(i) for i in __version__.split('.'))
 
 __all__ = [

--- a/requests_toolbelt/utils/user_agent.py
+++ b/requests_toolbelt/utils/user_agent.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
+import collections
 import platform
 import sys
 
 
 def user_agent(name, version, extras=None):
-    """
-    Returns an internet-friendly user_agent string.
+    """Return an internet-friendly user_agent string.
 
     The majority of this code has been wilfully stolen from the equivalent
     function in Requests.
@@ -17,35 +17,88 @@ def user_agent(name, version, extras=None):
     :returns: Formatted user-agent string
     :rtype: str
     """
-    try:
-        p_system = platform.system()
-        p_release = platform.release()
-    except IOError:
-        p_system = 'Unknown'
-        p_release = 'Unknown'
-
     if extras is None:
         extras = []
 
-    if any(len(extra) != 2 for extra in extras):
-        raise ValueError('Extras should be a sequence of two item tuples.')
+    return UserAgentBuilder(
+            name, version
+        ).include_extras(
+            extras
+        ).include_implementation(
+        ).include_system().build()
+
+
+class UserAgentBuilder(object):
+    """Class to provide a greater level of control than :func:`user_agent`.
+
+    This is used by :func:`user_agent` to build its User-Agent string.
+
+    .. code-block:: python
+
+        user_agent_str = UserAgentBuilder(
+                name='requests-toolbelt',
+                version='17.4.0',
+            ).include_implementation(
+            ).include_system(
+            ).include_extras([
+                ('requests', '2.14.2'),
+                ('urllib3', '1.21.2'),
+            ]).build()
+
+    """
 
     format_string = '%s/%s'
 
-    extra_pieces = [
-        format_string % (extra_name, extra_version)
-        for extra_name, extra_version in extras
-    ]
+    def __init__(self, name, version):
+        """Initialize our builder with the name and version of our user agent.
 
-    user_agent_pieces = ([format_string % (name, version)] + extra_pieces +
-                         [_implementation_string(),
-                          '%s/%s' % (p_system, p_release)])
+        :param str name:
+            Name of our user-agent.
+        :param str version:
+            The version string for user-agent.
+        """
+        self._pieces = collections.deque([(name, version)])
 
-    return " ".join(user_agent_pieces)
+    def build(self):
+        """Finalize the User-Agent string.
+
+        :returns:
+            Formatted User-Agent string.
+        :rtype:
+            str
+        """
+        return " ".join([self.format_string % piece for piece in self._pieces])
+
+    def include_extras(self, extras):
+        """Include extra portions of the User-Agent.
+
+        :param list extras:
+            list of tuples of extra-name and extra-version
+        """
+        if any(len(extra) != 2 for extra in extras):
+            raise ValueError('Extras should be a sequence of two item tuples.')
+
+        self._pieces.extend(extras)
+        return self
+
+    def include_implementation(self):
+        """Append the implementation string to the user-agent string.
+
+        This adds the the information that you're using CPython 2.7.13 to the
+        User-Agent.
+        """
+        self._pieces.append(_implementation_tuple())
+        return self
+
+    def include_system(self):
+        """Append the information about the Operating System."""
+        self._pieces.append(_platform_tuple())
+        return self
 
 
-def _implementation_string():
-    """
+def _implementation_tuple():
+    """Return the tuple of interpreter name and version.
+
     Returns a string that provides both the name and the version of the Python
     implementation currently running. For example, on CPython 2.7.5 it will
     return "CPython/2.7.5".
@@ -73,4 +126,18 @@ def _implementation_string():
     else:
         implementation_version = 'Unknown'
 
-    return "%s/%s" % (implementation, implementation_version)
+    return (implementation, implementation_version)
+
+
+def _implementation_string():
+    return "%s/%s" % _implementation_tuple()
+
+
+def _platform_tuple():
+    try:
+        p_system = platform.system()
+        p_release = platform.release()
+    except IOError:
+        p_system = 'Unknown'
+        p_release = 'Unknown'
+    return (p_system, p_release)

--- a/tests/test_user_agent.py
+++ b/tests/test_user_agent.py
@@ -15,6 +15,35 @@ class Object(object):
     pass
 
 
+class TestUserAgentBuilder(unittest.TestCase):
+    def test_only_user_agent_name(self):
+        assert 'fake/1.0.0' == ua.UserAgentBuilder('fake', '1.0.0').build()
+
+    def test_includes_extras(self):
+        expected = 'fake/1.0.0 another-fake/2.0.1 yet-another-fake/17.1.0'
+        actual = ua.UserAgentBuilder('fake', '1.0.0').include_extras([
+            ('another-fake', '2.0.1'),
+            ('yet-another-fake', '17.1.0'),
+        ]).build()
+        assert expected == actual
+
+    @patch('platform.python_implementation', return_value='CPython')
+    @patch('platform.python_version', return_value='2.7.13')
+    def test_include_implementation(self, *_):
+        expected = 'fake/1.0.0 CPython/2.7.13'
+        actual = ua.UserAgentBuilder('fake', '1.0.0').include_implementation(
+            ).build()
+        assert expected == actual
+
+    @patch('platform.system', return_value='Linux')
+    @patch('platform.release', return_value='4.9.5')
+    def test_include_system(self, *_):
+        expected = 'fake/1.0.0 Linux/4.9.5'
+        actual = ua.UserAgentBuilder('fake', '1.0.0').include_system(
+            ).build()
+        assert expected == actual
+
+
 class TestUserAgent(unittest.TestCase):
     def test_user_agent_provides_package_name(self):
         assert "my-package" in ua.user_agent("my-package", "0.0.1")


### PR DESCRIPTION
This gives folks more control over their User-Agent string that we
generate without forcing them to reveal information about their system
that they don't want.